### PR TITLE
docs: fix typo on astro nav

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1133,7 +1133,7 @@ export const docsMenu = {
                             url: '/tutorials/angular-analytics',
                         },
                         {
-                            name: 'Angular',
+                            name: 'Astro',
                             url: '/tutorials/astro-analytics',
                         },
                         {


### PR DESCRIPTION
## Changes

Just found out this watching the new [Theo video about Analytics](https://youtu.be/6xXSsu0YXWo). Fix the typo on the `Navbar`. It says `Angular` for the Astro Docs instead of `Astro`.

Before:


| Before | After |
|--------|--------|
| ![image](https://github.com/vicentematus/posthog.com/assets/38754555/dde62d7e-93fe-43e2-b34b-73c1b6e724cb) | ![image](https://github.com/vicentematus/posthog.com/assets/38754555/10dd2e10-c5d9-434a-8f2a-df613680e014) |
